### PR TITLE
Correction for using cgi without uncgi application

### DIFF
--- a/facets.cgi
+++ b/facets.cgi
@@ -3,6 +3,9 @@
 set facets_dir="{{some_dir_upon_to_your_decision}}/facets/" #directory where facets.pl  perl scripts is stored
 set perl_location="/exlibris/aleph/a2X_X/product/local/perl/bin/perl" #path and file to Aleph Perl. We recommend using Perl distributed with Aleph.
 ###
+#definition of variables from url arguments. 20190926
+WWW_searchset=`echo $QUERY_STRING | sed 's/^.*searchset=//' | sed 's/&.*$//''`
+WWW_noofrecs=`echo $QUERY_STRING | sed 's/^.*noofrecs=//' | sed 's/&.*$//''`
 
 
 echo 'Content-type: text/xml; charset=utf-8'


### PR DESCRIPTION
Variables WWW_{{urlArgument}} pushed to cgi script by Uncgi must be defined explicitely, if no Uncgi is used.